### PR TITLE
Upgrade ci deps

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -44,8 +44,6 @@ jobs:
           key: gradle-builds-core-${{ github.sha }}
           restore-keys: |
             gradle-builds
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Build with Gradle
         run: |
           ./gradlew :app:assembleRelease

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -14,18 +14,20 @@ jobs:
     name: Pull request check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@v1
         with:
           cmake-version: '3.22.1'
       - name: Prepare Java 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           java-package: jdk
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -35,7 +37,7 @@ jobs:
           restore-keys: |
             gradle-deps
       - name: Cache Gradle Build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches/build-cache-*
@@ -51,12 +53,12 @@ jobs:
           echo "APK_FILE=$(find app/build/outputs/apk/release -name '*.apk')" >> $GITHUB_ENV
           echo "DEMO_APK_FILE=$(find demo-app/build/outputs/apk/release -name '*.apk')" >> $GITHUB_ENV
       - name: Upload Artifacts(module)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ env.APK_FILE }}
           name: module-release
       - name: Upload Artifacts(demo-app)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ env.DEMO_APK_FILE }}
           name: demo-release

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -45,8 +45,6 @@ jobs:
           key: gradle-builds-core-${{ github.sha }}
           restore-keys: |
             gradle-builds
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Build with Gradle
         run: |
           ./gradlew :app:assembleRelease

--- a/.github/workflows/push_ci.yml
+++ b/.github/workflows/push_ci.yml
@@ -15,18 +15,20 @@ jobs:
     name: Build CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
+        uses: jwlawson/actions-setup-cmake@v1
         with:
           cmake-version: '3.22.1'
       - name: Prepare Java 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           java-package: jdk
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -36,7 +38,7 @@ jobs:
           restore-keys: |
             gradle-deps
       - name: Cache Gradle Build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches/build-cache-*
@@ -52,12 +54,12 @@ jobs:
           echo "APK_FILE=$(find app/build/outputs/apk/release -name '*.apk')" >> $GITHUB_ENV
           echo "DEMO_APK_FILE=$(find demo-app/build/outputs/apk/release -name '*.apk')" >> $GITHUB_ENV
       - name: Upload Artifacts(module)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ env.APK_FILE }}
           name: module-release
       - name: Upload Artifacts(demo-app)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           path: ${{ env.DEMO_APK_FILE }}
           name: demo-release


### PR DESCRIPTION
1. Node.js 12 actions are deprecated.
1. `gradlew` in svn is already 100755, and does not need to be granted again