### PR TITLE
[BUG FIX] Deprecated AppErrorInfo when dialog covers AppErrorsDetailActivity

### DIFF
--- a/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
+++ b/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
@@ -62,8 +62,7 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
     private var stackTrace = ""
 
     override fun onCreate() {
-        if (intent.parseAppErrorsInfo().not()) return
-
+        if (initUi(intent).not()) return
         binding.titleBackIcon.setOnClickListener { onBackPressed() }
         binding.disableAutoWrapErrorStackTraceSwitch.bind(ConfigData.DISABLE_AUTO_WRAP_ERROR_STACK_TRACE) {
             onInitialize {
@@ -82,12 +81,10 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
     /**
      * 从 [Intent] 中解析 [AppErrorsInfoBean] 并加载至界面
      *
-     * @receiver [Intent] 待解析的 [Intent] 实例
-     *
-     * @return [Boolean] 是否解析成功：true为成功；false为失败，可能是 [Intent] 为空或者 [AppErrorsInfoBean] 为空
+     * @return [Boolean] 是否解析成功：true 为成功；false 为失败，可能是 [Intent] 为空或者 [AppErrorsInfoBean] 为空
      */
-    private fun Intent?.parseAppErrorsInfo(): Boolean {
-        val appErrorsInfo = runCatching { this?.getSerializableExtraCompat<AppErrorsInfoBean>(EXTRA_APP_ERRORS_INFO) }.getOrNull()
+    private fun initUi(intent: Intent?): Boolean {
+        val appErrorsInfo = runCatching { intent?.getSerializableExtraCompat<AppErrorsInfoBean>(EXTRA_APP_ERRORS_INFO) }.getOrNull()
         if (appErrorsInfo == null) {
             toastAndFinish(name = "AppErrorsInfo")
             return false
@@ -179,9 +176,9 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
         intent?.removeExtra(EXTRA_APP_ERRORS_INFO)
         finish()
     }
+
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        if (intent.parseAppErrorsInfo()) binding.appPanelScrollView.scrollTo(0, 0)
+        if (initUi(intent)) binding.appPanelScrollView.scrollTo(0, 0)
     }
-
 }

--- a/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
+++ b/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
@@ -81,6 +81,7 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
     /**
      * 从 [Intent] 中解析 [AppErrorsInfoBean] 并加载至界面
      *
+     * @param intent 用于获取并解析 [AppErrorsInfoBean] 的 [Intent] 实例
      * @return [Boolean] 是否解析成功：true 为成功；false 为失败，可能是 [Intent] 为空或者 [AppErrorsInfoBean] 为空
      */
     private fun initUi(intent: Intent?): Boolean {

--- a/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
+++ b/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
@@ -62,8 +62,32 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
     private var stackTrace = ""
 
     override fun onCreate() {
+        if (!parseIntent(intent)) return
+
+        binding.titleBackIcon.setOnClickListener { onBackPressed() }
+
+        binding.disableAutoWrapErrorStackTraceSwitch.bind(ConfigData.DISABLE_AUTO_WRAP_ERROR_STACK_TRACE) {
+            onInitialize {
+                binding.errorStackTraceScrollView.isVisible = it
+                binding.errorStackTraceFixedText.isGone = it
+            }
+            onChanged {
+                reinitialize()
+                resetScrollView()
+            }
+        }
+
+        binding.detailTitleText.setOnClickListener { binding.appPanelScrollView.smoothScrollTo(0, 0) }
+
+        resetScrollView()
+    }
+
+    private fun parseIntent(intent: Intent?): Boolean {
         val appErrorsInfo = runCatching { intent?.getSerializableExtraCompat<AppErrorsInfoBean>(EXTRA_APP_ERRORS_INFO) }.getOrNull()
-            ?: return toastAndFinish(name = "AppErrorsInfo")
+        if (appErrorsInfo == null) {
+            toastAndFinish(name = "AppErrorsInfo")
+            return false
+        }
         if (appErrorsInfo.isEmpty) {
             binding.appPanelScrollView.isVisible = false
             showDialog {
@@ -80,10 +104,9 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
                 }
                 noCancelable()
             }
-            return
+            return false
         }
         binding.appInfoItem.setOnClickListener { openSelfSetting(appErrorsInfo.packageName) }
-        binding.titleBackIcon.setOnClickListener { onBackPressed() }
         binding.printIcon.setOnClickListener {
             loggerE(msg = appErrorsInfo.stackTrace)
             toast(LocaleString.printToLogcatSuccess)
@@ -122,23 +145,12 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
         binding.errorRecordTimeText.text = appErrorsInfo.dateTime
         binding.errorStackTraceMovableText.text = appErrorsInfo.stackTrace
         binding.errorStackTraceFixedText.text = appErrorsInfo.stackTrace
-        binding.disableAutoWrapErrorStackTraceSwitch.bind(ConfigData.DISABLE_AUTO_WRAP_ERROR_STACK_TRACE) {
-            onInitialize {
-                binding.errorStackTraceScrollView.isVisible = it
-                binding.errorStackTraceFixedText.isGone = it
-            }
-            onChanged {
-                reinitialize()
-                resetScrollView()
-            }
-        }
         binding.appPanelScrollView.setOnScrollChangeListener { _, _, y, _, _ ->
             binding.detailTitleText.text = if (y >= 30.dp(context = this))
                 appNameOf(appErrorsInfo.packageName).ifBlank { appErrorsInfo.packageName }
             else LocaleString.appName
         }
-        binding.detailTitleText.setOnClickListener { binding.appPanelScrollView.smoothScrollTo(0, 0) }
-        resetScrollView()
+        return true
     }
 
     /** 修复在一些小屏设备上设置了 [TextView.setTextIsSelectable] 后布局自动上滑问题 */
@@ -163,4 +175,11 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
         intent?.removeExtra(EXTRA_APP_ERRORS_INFO)
         finish()
     }
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        if (parseIntent(intent)) {
+            binding.appPanelScrollView.scrollTo(0, 0)
+        }
+    }
+
 }

--- a/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
+++ b/app/src/main/java/com/fankes/apperrorstracking/ui/activity/errors/AppErrorsDetailActivity.kt
@@ -62,10 +62,9 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
     private var stackTrace = ""
 
     override fun onCreate() {
-        if (!parseIntent(intent)) return
+        if (intent.parseAppErrorsInfo().not()) return
 
         binding.titleBackIcon.setOnClickListener { onBackPressed() }
-
         binding.disableAutoWrapErrorStackTraceSwitch.bind(ConfigData.DISABLE_AUTO_WRAP_ERROR_STACK_TRACE) {
             onInitialize {
                 binding.errorStackTraceScrollView.isVisible = it
@@ -76,14 +75,19 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
                 resetScrollView()
             }
         }
-
         binding.detailTitleText.setOnClickListener { binding.appPanelScrollView.smoothScrollTo(0, 0) }
-
         resetScrollView()
     }
 
-    private fun parseIntent(intent: Intent?): Boolean {
-        val appErrorsInfo = runCatching { intent?.getSerializableExtraCompat<AppErrorsInfoBean>(EXTRA_APP_ERRORS_INFO) }.getOrNull()
+    /**
+     * 从 [Intent] 中解析 [AppErrorsInfoBean] 并加载至界面
+     *
+     * @receiver [Intent] 待解析的 [Intent] 实例
+     *
+     * @return [Boolean] 是否解析成功：true为成功；false为失败，可能是 [Intent] 为空或者 [AppErrorsInfoBean] 为空
+     */
+    private fun Intent?.parseAppErrorsInfo(): Boolean {
+        val appErrorsInfo = runCatching { this?.getSerializableExtraCompat<AppErrorsInfoBean>(EXTRA_APP_ERRORS_INFO) }.getOrNull()
         if (appErrorsInfo == null) {
             toastAndFinish(name = "AppErrorsInfo")
             return false
@@ -146,7 +150,7 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
         binding.errorStackTraceMovableText.text = appErrorsInfo.stackTrace
         binding.errorStackTraceFixedText.text = appErrorsInfo.stackTrace
         binding.appPanelScrollView.setOnScrollChangeListener { _, _, y, _, _ ->
-            binding.detailTitleText.text = if (y >= 30.dp(context = this))
+            binding.detailTitleText.text = if (y >= 30.dp(context = this@AppErrorsDetailActivity))
                 appNameOf(appErrorsInfo.packageName).ifBlank { appErrorsInfo.packageName }
             else LocaleString.appName
         }
@@ -177,9 +181,7 @@ class AppErrorsDetailActivity : BaseActivity<ActivityAppErrorsDetailBinding>() {
     }
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        if (parseIntent(intent)) {
-            binding.appPanelScrollView.scrollTo(0, 0)
-        }
+        if (intent.parseAppErrorsInfo()) binding.appPanelScrollView.scrollTo(0, 0)
     }
 
 }


### PR DESCRIPTION
这是一个用于修复Bug的拉取请求。该提交修复了当崩溃提示对话框显示于AppErrorsDetailActivity上时，点击错误详情按钮无法显示最新的异常跟踪页面的问题。