### PR TITLE
添加 monochrome 图标

### DIFF
--- a/module-app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/module-app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/module-app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/module-app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
为了适配原生安卓的主题统一，现给 app 加上 monochrome 图标