### PR TITLE
fix: quick start title blocked by background activity launch

### DIFF
--- a/demo-app/src/main/java/com/fankes/apperrorsdemo/ui/activity/base/BaseActivity.kt
+++ b/demo-app/src/main/java/com/fankes/apperrorsdemo/ui/activity/base/BaseActivity.kt
@@ -46,7 +46,7 @@ abstract class BaseActivity<VB : ViewBinding> : AppCompatActivity() {
             name = "inflate"
             parameters(LayoutInflater::class)
         }?.invoke<VB>(layoutInflater) ?: error("binding failed")
-        if (Build.VERSION.SDK_INT >= 35) binding.root.fitsSystemWindows = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) binding.root.fitsSystemWindows = true
         setContentView(binding.root)
         /** 隐藏系统的标题栏 */
         supportActionBar?.hide()

--- a/module-app/src/main/java/com/fankes/apperrorstracking/service/QuickStartTileService.kt
+++ b/module-app/src/main/java/com/fankes/apperrorstracking/service/QuickStartTileService.kt
@@ -21,15 +21,29 @@
  */
 package com.fankes.apperrorstracking.service
 
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Build
 import android.service.quicksettings.TileService
 import com.fankes.apperrorstracking.ui.activity.errors.AppErrorsRecordActivity
-import com.fankes.apperrorstracking.utils.factory.navigate
+import com.fankes.apperrorstracking.utils.factory.toast
+import com.highcapable.kavaref.extension.classOf
 
 class QuickStartTileService : TileService() {
 
+    @Suppress("DEPRECATION")
+    @SuppressLint("StartActivityAndCollapseDeprecated")
     override fun onClick() {
         super.onClick()
-        /** 启动异常历史记录窗口 */
-        navigate<AppErrorsRecordActivity>()
+        val activity = classOf<AppErrorsRecordActivity>()
+        runCatching {
+            val intent = Intent(this, activity).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+                startActivityAndCollapse(PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE))
+            else startActivityAndCollapse(intent)
+        }.onFailure { toast(msg = "Start ${activity.name} failed") }
     }
 }

--- a/module-app/src/main/java/com/fankes/apperrorstracking/ui/activity/base/BaseActivity.kt
+++ b/module-app/src/main/java/com/fankes/apperrorstracking/ui/activity/base/BaseActivity.kt
@@ -49,7 +49,7 @@ abstract class BaseActivity<VB : ViewBinding> : AppCompatActivity() {
             name = "inflate"
             parameters(LayoutInflater::class)
         }?.invoke<VB>(layoutInflater) ?: error("binding failed")
-        if (Build.VERSION.SDK_INT >= 35) binding.root.fitsSystemWindows = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) binding.root.fitsSystemWindows = true
         setContentView(binding.root)
         /** 隐藏系统的标题栏 */
         supportActionBar?.hide()

--- a/module-app/src/main/java/com/fankes/apperrorstracking/utils/factory/FunctionFactory.kt
+++ b/module-app/src/main/java/com/fankes/apperrorstracking/utils/factory/FunctionFactory.kt
@@ -128,7 +128,7 @@ fun Resources.colorOf(@ColorRes resId: Int) = ResourcesCompat.getColor(this, res
  */
 private fun Context.getPackageInfoCompat(packageName: String, flag: Number = 0) = runCatching {
     @Suppress("DEPRECATION", "KotlinRedundantDiagnosticSuppress")
-    if (Build.VERSION.SDK_INT >= 33)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
         packageManager?.getPackageInfo(packageName, PackageInfoFlags.of(flag.toLong()))
     else packageManager?.getPackageInfo(packageName, flag.toInt())
 }.getOrNull()
@@ -145,7 +145,7 @@ private val PackageInfo.versionCodeCompat get() = PackageInfoCompat.getLongVersi
  */
 fun Context.listOfPackages() = runCatching {
     @Suppress("DEPRECATION", "KotlinRedundantDiagnosticSuppress")
-    if (Build.VERSION.SDK_INT >= 33)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
         packageManager?.getInstalledPackages(PackageInfoFlags.of(PackageManager.GET_CONFIGURATIONS.toLong()))
     else packageManager?.getInstalledPackages(PackageManager.GET_CONFIGURATIONS)
 }.getOrNull() ?: emptyList()
@@ -218,7 +218,7 @@ fun Context.appIconOf(packageName: String = getPackageName()) =
  */
 inline fun <reified T : Serializable> Intent.getSerializableExtraCompat(key: String): T? {
     @Suppress("DEPRECATION")
-    return if (Build.VERSION.SDK_INT >= 33)
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
         getSerializableExtra(key, T::class.java)
     else getSerializableExtra(key) as? T?
 }


### PR DESCRIPTION
## 描述

- 将 SDK数字 替换为 Build.VERSION_CODES 常量
- 修复 快捷启动磁贴 被 后台启动限制 拦截

## 验证

- 修复后 在我的 Android 16 上可以正常从磁贴打开异常记录页
