### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README-ja-JP.md
+++ b/README-ja-JP.md
@@ -93,7 +93,7 @@ PCに接続できない、ADBが実行できない状態である場合にこの
 
 ## Starの推移
 
-![Star History Chart](https://api.star-history.com/svg?repos=KitsunePie/AppErrorsTracking&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=KitsunePie/AppErrorsTracking&type=Date)
 
 ## ライセンス
 

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -103,7 +103,7 @@
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=KitsunePie/AppErrorsTracking&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=KitsunePie/AppErrorsTracking&type=Date)
 
 ## 许可证
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ We have nothing to do with versions downloaded from other informal channels or a
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=KitsunePie/AppErrorsTracking&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=KitsunePie/AppErrorsTracking&type=Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the READMEs is currently broken because the upstream service relies on GitHub's stargazer API, which now restricts these requests. Switch the charts to a working mirror so the project history displays correctly again.